### PR TITLE
Require classes in Bumpver

### DIFF
--- a/lib/bumpver.rb
+++ b/lib/bumpver.rb
@@ -1,2 +1,8 @@
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 module Bumpver
 end
+
+require 'bumpver/version'
+require 'bumpver/version_file'


### PR DESCRIPTION
Setting the load path makes the requires in this and other Bumpver
files look in bumpver’s lib folder first.

Requiring the version and version_file files here allows us to access
them easily from another ruby program or IRB. Bumpver is the entry
point for all its other functionality.
