### PR TITLE
Add Rspec matcher match_version for asserting versions

### DIFF
--- a/spec/lib/bumpver/version_spec.rb
+++ b/spec/lib/bumpver/version_spec.rb
@@ -8,41 +8,51 @@ module Bumpver
     PATCH=6
   end
 
+  RSpec::Matchers.define :match_version do |expected|
+    match do |actual|
+      actual.to_s == expected
+    end
+
+    description do
+      "match version #{expected}"
+    end
+  end
+
   describe Version do
     Given(:version) { described_class.new major, minor, patch }
     Given(:major) { 1 }
     Given(:minor) { 2 }
     Given(:patch) { 3 }
 
-    Then { version.to_s == "1.2.3" }
+    Then { expect(version).to match_version "1.2.3" }
     And { version.major == major }
     And { version.minor == minor }
     And { version.patch == patch }
 
-    Then { version.next_major.to_s == "2.0.0" }
-    Then { version.next_minor.to_s == "1.3.0" }
-    Then { version.next_patch.to_s == "1.2.4" }
+    Then { expect(version.next_major).to match_version "2.0.0" }
+    Then { expect(version.next_minor).to match_version "1.3.0" }
+    Then { expect(version.next_patch).to match_version "1.2.4" }
 
     context "with pre-release version" do
       Given(:version) { described_class.new major, minor, patch, pre }
       Given(:pre) { "alpha" }
 
-      Then { version.to_s == "1.2.3-alpha" }
+      Then { expect(version).to match_version "1.2.3-alpha" }
       And { version.pre == "alpha" }
-      Then { version.next_major.to_s == "2.0.0" }
-      Then { version.next_minor.to_s == "1.3.0" }
-      Then { version.next_patch.to_s == "1.2.4" }
+      Then { expect(version.next_major).to match_version "2.0.0" }
+      Then { expect(version.next_minor).to match_version "1.3.0" }
+      Then { expect(version.next_patch).to match_version "1.2.4" }
     end
 
     context "with build version" do
       Given(:version) { described_class.new major, minor, patch, nil, build }
       Given(:build) { "0e65410" }
 
-      Then { version.to_s == "1.2.3+0e65410" }
+      Then { expect(version).to match_version "1.2.3+0e65410" }
       And { version.build == "0e65410" }
-      Then { version.next_major.to_s == "2.0.0" }
-      Then { version.next_minor.to_s == "1.3.0" }
-      Then { version.next_patch.to_s == "1.2.4" }
+      Then { expect(version.next_major).to match_version "2.0.0" }
+      Then { expect(version.next_minor).to match_version "1.3.0" }
+      Then { expect(version.next_patch).to match_version "1.2.4" }
     end
 
     context "with both pre-release and build version" do
@@ -50,17 +60,17 @@ module Bumpver
       Given(:pre) { "alpha" }
       Given(:build) { "0e65410" }
 
-      Then { version.to_s == "1.2.3-alpha+0e65410" }
+      Then { expect(version).to match_version "1.2.3-alpha+0e65410" }
       And { version.pre == "alpha" }
       And { version.build == "0e65410" }
-      Then { version.next_major.to_s == "2.0.0" }
-      Then { version.next_minor.to_s == "1.3.0" }
-      Then { version.next_patch.to_s == "1.2.4" }
+      Then { expect(version.next_major).to match_version "2.0.0" }
+      Then { expect(version.next_minor).to match_version "1.3.0" }
+      Then { expect(version.next_patch).to match_version "1.2.4" }
     end
 
     describe "::from_constants" do
       Given(:version) { described_class.from_constants SomeVersion }
-      Then { version.to_s == "4.5.6" }
+      Then { expect(version).to match_version "4.5.6" }
     end
 
     describe "::from_string" do
@@ -68,32 +78,32 @@ module Bumpver
 
       context "with only major" do
         Given(:string) { "42" }
-        Then { version.to_s == "42.0.0" }
+        Then { expect(version).to match_version "42.0.0" }
       end
 
       context "with major.minor" do
         Given(:string) { "42.7" }
-        Then { version.to_s == "42.7.0" }
+        Then { expect(version).to match_version "42.7.0" }
       end
 
       context "with major.minor.patch" do
         Given(:string) { "42.7.5" }
-        Then { version.to_s == "42.7.5" }
+        Then { expect(version).to match_version "42.7.5" }
       end
 
       context "with pre-release" do
         Given(:string) { "42.7.5-alpha" }
-        Then { version.to_s == "42.7.5-alpha" }
+        Then { expect(version).to match_version "42.7.5-alpha" }
       end
 
       context "with build" do
         Given(:string) { "42.7.5+0e65410" }
-        Then { version.to_s == "42.7.5+0e65410" }
+        Then { expect(version).to match_version "42.7.5+0e65410" }
       end
 
       context "with pre-release and build" do
         Given(:string) { "42.7.5-alpha+0e65410" }
-        Then { version.to_s == "42.7.5-alpha+0e65410" }
+        Then { expect(version).to match_version "42.7.5-alpha+0e65410" }
       end
     end
 


### PR DESCRIPTION
rspec-given makes the tests quite readable. I find the .to_s == to be jarring in terms of reading what’s going on. To help make the assertions read more like an English sentence, I added a custom RSpec matcher.
