### PR TITLE
Modify version equality to allow comparison with strings

### DIFF
--- a/lib/bumpver/version.rb
+++ b/lib/bumpver/version.rb
@@ -40,11 +40,15 @@ module Bumpver
     end
 
     def ==(other)
-      major == other.major &&
-        minor == other.minor &&
-        patch == other.patch &&
-        pre == other.pre &&
-        build == other.build
+      if other.is_a?(String)
+        self.to_s == other
+      else
+        major == other.major &&
+          minor == other.minor &&
+          patch == other.patch &&
+          pre == other.pre &&
+          build == other.build
+      end
     end
 
     def to_s

--- a/spec/lib/bumpver/version_spec.rb
+++ b/spec/lib/bumpver/version_spec.rb
@@ -14,35 +14,35 @@ module Bumpver
     Given(:minor) { 2 }
     Given(:patch) { 3 }
 
-    Then { version.to_s == "1.2.3" }
+    Then { version == "1.2.3" }
     And { version.major == major }
     And { version.minor == minor }
     And { version.patch == patch }
 
-    Then { version.next_major.to_s == "2.0.0" }
-    Then { version.next_minor.to_s == "1.3.0" }
-    Then { version.next_patch.to_s == "1.2.4" }
+    Then { version.next_major == "2.0.0" }
+    Then { version.next_minor == "1.3.0" }
+    Then { version.next_patch == "1.2.4" }
 
     context "with pre-release version" do
       Given(:version) { described_class.new major, minor, patch, pre }
       Given(:pre) { "alpha" }
 
-      Then { version.to_s == "1.2.3-alpha" }
+      Then { version == "1.2.3-alpha" }
       And { version.pre == "alpha" }
-      Then { version.next_major.to_s == "2.0.0" }
-      Then { version.next_minor.to_s == "1.3.0" }
-      Then { version.next_patch.to_s == "1.2.4" }
+      Then { version.next_major == "2.0.0" }
+      Then { version.next_minor == "1.3.0" }
+      Then { version.next_patch == "1.2.4" }
     end
 
     context "with build version" do
       Given(:version) { described_class.new major, minor, patch, nil, build }
       Given(:build) { "0e65410" }
 
-      Then { version.to_s == "1.2.3+0e65410" }
+      Then { version == "1.2.3+0e65410" }
       And { version.build == "0e65410" }
-      Then { version.next_major.to_s == "2.0.0" }
-      Then { version.next_minor.to_s == "1.3.0" }
-      Then { version.next_patch.to_s == "1.2.4" }
+      Then { version.next_major == "2.0.0" }
+      Then { version.next_minor == "1.3.0" }
+      Then { version.next_patch == "1.2.4" }
     end
 
     context "with both pre-release and build version" do
@@ -50,17 +50,17 @@ module Bumpver
       Given(:pre) { "alpha" }
       Given(:build) { "0e65410" }
 
-      Then { version.to_s == "1.2.3-alpha+0e65410" }
+      Then { version == "1.2.3-alpha+0e65410" }
       And { version.pre == "alpha" }
       And { version.build == "0e65410" }
-      Then { version.next_major.to_s == "2.0.0" }
-      Then { version.next_minor.to_s == "1.3.0" }
-      Then { version.next_patch.to_s == "1.2.4" }
+      Then { version.next_major == "2.0.0" }
+      Then { version.next_minor == "1.3.0" }
+      Then { version.next_patch == "1.2.4" }
     end
 
     describe "::from_constants" do
       Given(:version) { described_class.from_constants SomeVersion }
-      Then { version.to_s == "4.5.6" }
+      Then { version == "4.5.6" }
     end
 
     describe "::from_string" do
@@ -68,32 +68,32 @@ module Bumpver
 
       context "with only major" do
         Given(:string) { "42" }
-        Then { version.to_s == "42.0.0" }
+        Then { version == "42.0.0" }
       end
 
       context "with major.minor" do
         Given(:string) { "42.7" }
-        Then { version.to_s == "42.7.0" }
+        Then { version == "42.7.0" }
       end
 
       context "with major.minor.patch" do
         Given(:string) { "42.7.5" }
-        Then { version.to_s == "42.7.5" }
+        Then { version == "42.7.5" }
       end
 
       context "with pre-release" do
         Given(:string) { "42.7.5-alpha" }
-        Then { version.to_s == "42.7.5-alpha" }
+        Then { version == "42.7.5-alpha" }
       end
 
       context "with build" do
         Given(:string) { "42.7.5+0e65410" }
-        Then { version.to_s == "42.7.5+0e65410" }
+        Then { version == "42.7.5+0e65410" }
       end
 
       context "with pre-release and build" do
         Given(:string) { "42.7.5-alpha+0e65410" }
-        Then { version.to_s == "42.7.5-alpha+0e65410" }
+        Then { version == "42.7.5-alpha+0e65410" }
       end
     end
 


### PR DESCRIPTION
Updated the Version#== method to covert self to a string and then do a comparison with the other string. I thought this would help make the interface more natural.

The specs compare versions to strings a lot, and manually converting to string each time felt tedious and interrupted the flow of the assertions.
